### PR TITLE
Chore: setup theme context

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,17 +6,17 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
-    "userInterfaceStyle": "dark",
     "splash": {
       "image": "./assets/images/splash.png",
       "resizeMode": "contain",
       "backgroundColor": "#ffffff"
     },
-    "assetBundlePatterns": [
-      "**/*"
-    ],
+    "assetBundlePatterns": ["**/*"],
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "config": {
+        "usesNonExemptEncryption": false
+      }
     },
     "android": {
       "adaptiveIcon": {
@@ -29,9 +29,7 @@
       "output": "static",
       "favicon": "./assets/images/favicon.png"
     },
-    "plugins": [
-      "expo-router"
-    ],
+    "plugins": ["expo-router", "expo-secure-store"],
     "experiments": {
       "typedRoutes": true
     }

--- a/app/(auth)/SignIn&SignOut/SetYourFingerPrint.tsx
+++ b/app/(auth)/SignIn&SignOut/SetYourFingerPrint.tsx
@@ -1,8 +1,12 @@
 import { Text, View } from "@/components/Themed";
 import { LeftArrow } from "@/components/UI/icons";
+import { ThemeContext } from "@/ctx/ThemeContext";
+import { useContext, useEffect } from "react";
 import { SvgUri, SvgXml } from "react-native-svg";
 
 export default function SetYourFingerPrint() {
+  const { theme, changeTheme } = useContext(ThemeContext);
+
   return (
     <>
       <Text>Set Your Finger Print</Text>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,16 +1,15 @@
 import FontAwesome from "@expo/vector-icons/FontAwesome";
-import {
-  DarkTheme,
-  DefaultTheme,
-  ThemeProvider,
-} from "@react-navigation/native";
 import { useFonts } from "expo-font";
 import { Stack } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
+import * as SecureStore from "expo-secure-store";
 
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 
-import { useColorScheme } from "@/components/useColorScheme";
+import ThemeProvider, { ThemeContext } from "@/ctx/ThemeContext";
+import { Pressable, View, useColorScheme } from "react-native";
+import { ThemeType } from "@/constants/Types";
+import { Text } from "@/components/Themed";
 
 export {
   // Catch any errors thrown by the Layout component.
@@ -34,33 +33,59 @@ export default function RootLayout() {
     ...FontAwesome.font,
   });
 
+  const systemTheme = useColorScheme() as ThemeType;
+
+  const [favoredTheme, setFavoredTheme] = useState<ThemeType>(null);
+
+  useEffect(() => {
+    async function getCustomTheme() {
+      try {
+        let favoredTheme = (await SecureStore.getItemAsync(
+          "theme"
+        )) as ThemeType;
+
+        if (!favoredTheme) {
+          favoredTheme = systemTheme;
+        }
+
+        setFavoredTheme(favoredTheme);
+      } catch (e) {
+        console.log(e);
+      }
+    }
+
+    getCustomTheme();
+  }, []);
+
   // Expo Router uses Error Boundaries to catch errors in the navigation tree.
   useEffect(() => {
     if (error) throw error;
   }, [error]);
 
   useEffect(() => {
-    if (loaded) {
+    if (loaded && favoredTheme) {
       SplashScreen.hideAsync();
     }
-  }, [loaded]);
+  }, [loaded, favoredTheme]);
 
   if (!loaded) {
     return null;
   }
 
-  return <RootLayoutNav />;
+  return (
+    <ThemeProvider theme={favoredTheme}>
+      <RootLayoutNav />
+    </ThemeProvider>
+  );
 }
 
 function RootLayoutNav() {
-  const colorScheme = useColorScheme();
-
   return (
-    <ThemeProvider value={colorScheme === "light" ? DarkTheme : DefaultTheme}>
+    <>
       <Stack initialRouteName="(auth)">
         <Stack.Screen name="(auth)" options={{ headerShown: false }} />
         <Stack.Screen name="modal" options={{ presentation: "modal" }} />
       </Stack>
-    </ThemeProvider>
+    </>
   );
 }

--- a/constants/Types.ts
+++ b/constants/Types.ts
@@ -1,0 +1,1 @@
+export type ThemeType = "light" | "dark" | null

--- a/ctx/ThemeContext.tsx
+++ b/ctx/ThemeContext.tsx
@@ -1,0 +1,33 @@
+import { ThemeType } from "@/constants/Types";
+import React, { createContext, useState } from "react";
+import * as SecureStore from "expo-secure-store";
+
+interface ContextType {
+  theme: ThemeType;
+  changeTheme: (theme: "light" | "dark") => void;
+}
+
+export const ThemeContext = createContext<ContextType>({
+  theme: null,
+  changeTheme: (theme: "light" | "dark") => {},
+});
+
+interface Props {
+  children: React.JSX.Element | React.JSX.Element[];
+  theme: ThemeType;
+}
+
+export default function ThemeProvider({ children, theme: value }: Props) {
+  const [theme, setTheme] = useState<ThemeType>(value);
+
+  async function changeTheme(theme: "light" | "dark") {
+    setTheme(theme);
+    await SecureStore.setItemAsync("theme", theme!);
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme: theme, changeTheme: changeTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "expo-linear-gradient": "~12.7.2",
         "expo-linking": "~6.2.2",
         "expo-router": "~3.4.10",
+        "expo-secure-store": "~12.8.1",
         "expo-splash-screen": "~0.26.5",
         "expo-status-bar": "~1.11.1",
         "expo-system-ui": "~2.9.3",
@@ -10018,6 +10019,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
@@ -11163,6 +11176,14 @@
         "react-native-reanimated": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-secure-store": {
+      "version": "12.8.1",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-12.8.1.tgz",
+      "integrity": "sha512-Ju3jmkHby4w7rIzdYAt9kQyQ7HhHJ0qRaiQOInknhOLIltftHjEgF4I1UmzKc7P5RCfGNmVbEH729Pncp/sHXQ==",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-splash-screen": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "react-native-screens": "~3.29.0",
     "react-native-svg": "^15.2.0",
     "react-native-web": "~0.19.6",
-    "expo-linear-gradient": "~12.7.2"
+    "expo-linear-gradient": "~12.7.2",
+    "expo-secure-store": "~12.8.1"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
### What does this PR do?
- This pull request sets up a custom theme context to manage themes throughout the app.

### Description
- It has two values theme and changeTheme.
- Theme: Is a string that only accepts 'light' or 'dark'
- Change Theme accepts light or dark and change the current theme.


### How can this be manually tested?
- This can be done manually by accessing the theme state and setting colors based on its value. After you'll have to create a button that changes the value of the theme on press.